### PR TITLE
Remove non-ASCII chars from help doc's first line

### DIFF
--- a/doc/textobj-quote.txt
+++ b/doc/textobj-quote.txt
@@ -1,4 +1,4 @@
-*textobj-quote.txt*	Support typographic (“‘curly’”) quote characters.
+*textobj-quote.txt*	Support typographic quote characters.
 
 ==============================================================================
 CONTENTS					*textobj-quote-contents*


### PR DESCRIPTION
Vim does not support non-ASCII characters in help documents. They can
lead to an error when building help tags.  See the following link for
details:

https://github.com/vim/vim/issues/2213#issuecomment-337878041

However, if we remove the non-ASCII characters from just the first line
of the document, then help tags build correctly.

The alternative is to rename the document from *.txt to *.??x, which
seems more confusing than changing one line. (In the future, if we have
to choose between removing *all* the non-ASCII characters and changing
the filename, I would support changing the filename.)

This should fix #29. Thanks to @Freed-Wu for teaching us about this
corner case.